### PR TITLE
feat(interactive): adds configuration.xml file override

### DIFF
--- a/inspire/interactive/templates/configxml-configmap.yaml
+++ b/inspire/interactive/templates/configxml-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and (not .Values.configurationXmlConfigMap) .Values.configurationXml }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-configuration-xml" (include "interactive.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "interactive.labels" . | nindent 4 }}
+data:
+  configuration.xml: |
+{{ .Values.configurationXml | nindent 4 }}
+{{- end }}

--- a/inspire/interactive/templates/deployment.yaml
+++ b/inspire/interactive/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
             - name: interactive-demo-mode-files
               mountPath: /opt/QuadientInteractive/config/demo-mode
             {{- end }}
+            {{- if or .Values.configurationXmlConfigMap .Values.configurationXml}}
+            - name: interactive-configuration-xml
+              mountPath: /opt/QuadientInteractive/config/configuration.xml
+            {{- end }}
         - name: ips
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -147,6 +151,16 @@ spec:
         - name: interactive-demo-mode-files
           persistentVolumeClaim:
             claimName: {{ .Values.demoModeFiles }}
+            readOnly: true
+        {{- end }}
+        {{- if or .Values.configurationXmlConfigMap .Values.configurationXml}}
+        - name: interactive-configuration-xml
+          persistentVolumeClaim:
+            {{- if .Values.configurationXmlConfigMap }}
+            claimName: {{ .Values.configurationXmlConfigMap }}
+            {{- else }}
+            claimName: {{ printf "%s-configuration-xml" (include "interactive.fullname" .) }}
+            {{- end }}
             readOnly: true
         {{- end }}
       {{- with .Values.nodeSelector }}

--- a/inspire/interactive/values.yaml
+++ b/inspire/interactive/values.yaml
@@ -62,16 +62,22 @@ useHttp: true
 nameOverride: ''
 # -- Fully override the name used for chart objects
 fullnameOverride: ''
-# -- Name of a pre-existing configmap to use (one will be created by default)
+# -- Name of a pre-existing ConfigMap to use (one will be created by default)
 existingConfigMap: ''
 # -- Name of a pre-existing secret to use (one will be created by default)
 existingSecret: ''
 # -- Name of a PVC to mount to the config directory for demo-mode use
 # Note: Will be ignored when productionEnvironment is set to true
 demoModeFiles: ''
+# -- XML content to be mapped over the `configuration.xml` provided with the image
+# Note: Will be ignored when `configurationXmlConfigMap` is set
+configurationXml: ''
+# -- Name of a ConfigMap containing a `configuration.xml` data value to substitute
+# Note: Takes precedence over `configurationXml` value
+configurationXmlConfigMap: ''
 
 ##
-# Scaler deployment resource paramaters
+# Scaler deployment resource parameters
 ##
 # -- Number of Interactive containers to deploy
 replicaCount: 1


### PR DESCRIPTION
Adds two new configuration values (`configurationXml` and `configurationXmlConfigMap`) that can be used to replace the configuration.xml file provided by the image.

XML content can be specified inline via the `configurationXml` value and a ConfigMap will be created (if it does not already exist). If a name (ConfigMap) is provided via the `configurationXmlConfigMap` value, the existing ConfigMap will be used instead.

Ref: #6