### PR TITLE
feat[docuhost]: embedded mongodb dependency (@13.6.1)

### DIFF
--- a/docuhost/Chart.lock
+++ b/docuhost/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.6.1
+digest: sha256:d7587dfa34b5eeabd8cecc523c553e2dae2c625a7f5723afb20dad3d65b78671
+generated: "2022-12-16T16:40:33.454469-05:00"

--- a/docuhost/Chart.yaml
+++ b/docuhost/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
-name: docuhost
-description: A Helm chart to deploy the Document Host (Docuhost) demo service
-type: application
 appVersion: 0.3.4
+dependencies:
+  - name: mongodb
+    version: 13.6.1
+    repository: https://charts.bitnami.com/bitnami
+description: A Helm chart to deploy the Document Host (Docuhost) demo service
+name: docuhost
+type: application
 version: 0.1.11

--- a/docuhost/templates/NOTES.txt
+++ b/docuhost/templates/NOTES.txt
@@ -1,10 +1,9 @@
-1. Get the application URL by running these commands:
+Chart installation complete. ({{ printf "%s:%s" .Chart.Name .Chart.Version }})
+Changes can be applied by referencing the '{{ .Release.Name }}' release.
+
+Access the Application:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}{{ .Values.ingress.path }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "docuhost.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")


### PR DESCRIPTION
This PR solidifies the dependency on the bitnami/mongodb chart by embedding it with the build. Bumped chart version to v13.6.1.