### PR TITLE
[docuhost]  Release v0.1.13

### DIFF
--- a/docuhost/Chart.lock
+++ b/docuhost/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 13.6.1
-digest: sha256:d7587dfa34b5eeabd8cecc523c553e2dae2c625a7f5723afb20dad3d65b78671
-generated: "2022-12-16T16:40:33.454469-05:00"
+  version: 13.9.3
+digest: sha256:a4a3aacd1d85c037950ddf0b987f2b60d5d332557a07454bd98f7d9fc2909f48
+generated: "2023-03-31T17:36:38.087977-05:00"

--- a/docuhost/Chart.yaml
+++ b/docuhost/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 0.3.4
+appVersion: 0.3.6
 dependencies:
   - name: mongodb
-    version: 13.6.1
+    version: 13.9.3
     repository: https://charts.bitnami.com/bitnami
 description: A Helm chart to deploy the Document Host (Docuhost) demo service
 name: docuhost
 type: application
-version: 0.1.12
+version: 0.1.13

--- a/docuhost/templates/deployment.yaml
+++ b/docuhost/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "docuhost.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/docuhost/values.yaml
+++ b/docuhost/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- DocuHost image repository
   repository: registry.sptcloud.com/spt/docuhost
   # -- Override tag specified by `appVersion` in the chart file
-  tag: 0.3.4-1cffaec
+  tag: ""
   # -- DocuHost image pull policy
   pullPolicy: IfNotPresent
 # -- List of image repository pull secrets


### PR DESCRIPTION
* Updates app version for docuhost v0.3.6
* Fixes mongodb restart issue: must have exclusive disk access on startup so rolling update doesn't work
