### PR TITLE
feat: add initContainer to wait for mongodb

### DIFF
--- a/docuhost/templates/configmap.yaml
+++ b/docuhost/templates/configmap.yaml
@@ -4,8 +4,8 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-configuration" (include "docuhost.fullname" .) }}
   namespace: {{ .Release.Namespace | quote }}
-  labels:
-    {{- include "docuhost.labels" . | nindent 4 }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
 data:
   app-url: {{ required "A value for 'app.url' is required." .Values.app.url | quote }}
   db-prefix: {{ required "A value for 'db.prefix' is required." .Values.db.prefix | quote }}

--- a/docuhost/templates/deployment.yaml
+++ b/docuhost/templates/deployment.yaml
@@ -2,38 +2,46 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "docuhost.fullname" . }}
-  labels:
-    {{- include "docuhost.labels" . | nindent 4 }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
-    matchLabels:
-      {{- include "docuhost.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "docuhost.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: docuhost
   strategy:
     type: Recreate
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{ .Values.podAnnotations | toYaml | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "docuhost.selectorLabels" . | nindent 8 }}
+      labels: {{- include "docuhost.labels" . | nindent 8 }}
+        app.kubernetes.io/component: docuhost
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "docuhost.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-db
+          image: {{ .Values.wait.image.name }}:{{ .Values.wait.image.tag }}
+          imagePullPolicy: {{ .Values.wait.image.pullPolicy }}
+          args:
+            - pod
+            - -lapp.kubernetes.io/component=mongodb
+            - -lapp.kubernetes.io/instance={{ .Release.Name }}
       containers:
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        - name: docuhost
+          {{- if .Values.securityContext }}
+          securityContext: {{- .Values.securityContext | toYaml | nindent 12 }}
+          {{- end }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- include "docuhost.env.database" . | nindent 12 }}
@@ -93,17 +101,15 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
+          {{- if .Values.resources }}
+          resources: {{- .Values.resources | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.affinity }}
+      affinity: {{- .Values.affinity | toYaml | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- .Values.tolerations | toYaml | nindent 8 }}
       {{- end }}

--- a/docuhost/templates/deployment.yaml
+++ b/docuhost/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
           args:
             - pod
             - -lapp.kubernetes.io/component=mongodb
-            - -lapp.kubernetes.io/instance={{ .Release.Name }}
       containers:
         - name: docuhost
           {{- if .Values.securityContext }}

--- a/docuhost/templates/hpa.yaml
+++ b/docuhost/templates/hpa.yaml
@@ -3,8 +3,8 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "docuhost.fullname" . }}
-  labels:
-    {{- include "docuhost.labels" . | nindent 4 }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/docuhost/templates/ingress.yaml
+++ b/docuhost/templates/ingress.yaml
@@ -16,8 +16,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    {{- include "docuhost.labels" . | nindent 4 }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/docuhost/templates/pod-reader-role.yaml
+++ b/docuhost/templates/pod-reader-role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "docuhost.fullname" . }}-pod-reader
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch

--- a/docuhost/templates/pod-reader-rolebinding.yaml
+++ b/docuhost/templates/pod-reader-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "docuhost.fullname" . }}-pod-reader
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "docuhost.fullname" . }}-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "docuhost.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace . | quote }}

--- a/docuhost/templates/pod-reader-rolebinding.yaml
+++ b/docuhost/templates/pod-reader-rolebinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "docuhost.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace . | quote }}
+    namespace: {{ .Release.Namespace | quote }}

--- a/docuhost/templates/secrets.yaml
+++ b/docuhost/templates/secrets.yaml
@@ -4,8 +4,8 @@ kind: Secret
 metadata:
   name: {{ include "docuhost.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels:
-    {{- include "docuhost.labels" . | nindent 4 }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
 type: Opaque
 data:
   db-username: {{ required "A value for 'db.username' is required." .Values.db.username | b64enc | quote }}

--- a/docuhost/templates/service.yaml
+++ b/docuhost/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ include "docuhost.fullname" . }}
   labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -16,3 +17,4 @@ spec:
       {{- end }}
       name: http
   selector: {{- include "docuhost.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost

--- a/docuhost/templates/serviceaccount.yaml
+++ b/docuhost/templates/serviceaccount.yaml
@@ -3,10 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "docuhost.serviceAccountName" . }}
-  labels:
-    {{- include "docuhost.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docuhost
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/docuhost/values.yaml
+++ b/docuhost/values.yaml
@@ -196,7 +196,17 @@ ingress:
   # annotations:
   #   kubernetes.io/ingress.class: nginx
   #   cert-manager.io/cluster-issuer: cluster-issuer-name
-  annotations: { }
+  annotations: {}
   # -- Enable TLS configuration for the host defined at `ingress.hostname` parameter
   # TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   tls: false
+
+# ref: https://github.com/groundnuty/k8s-wait-for
+wait:
+  image:
+    # -- k8s-wait-for image name
+    name: ghcr.io/groundnuty/k8s-wait-for
+    # -- k8s-wait-for image tag
+    tag: no-root-v2.0
+    # -- k8s-wait-for image pull policy
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Adds support for k8s-wait-for script so docuhost container does not try to start (and fail) before mongodb is available.