### PR TITLE
ci: bring up Tier 1 validation and tag-triggered OCI release for inspire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+# CI for the inspire chart (Tier 1: schema-only).
+#
+# This workflow validates that the chart and its CI fixtures render and
+# admit cleanly. It does NOT install or pull real Inspire images — those
+# live behind credentialled Harbor that GitHub-hosted runners cannot reach,
+# and putting Harbor/ACR creds in repo secrets is the wrong trust boundary.
+# Real-image smoke-testing is a local pre-tag step (see RELEASING.md when added).
+#
+# Gates (fast → slow):
+#   1. helm lint       — deprecated APIs, missing Chart.yaml fields
+#   2. helm template   — every fixture under inspire/ci/ must render
+#   3. kubeconform     — rendered manifests validate against K8s OpenAPI
+#   4. helm install --dry-run=server on KinD — admission/webhook checks
+#
+# Scope: inspire only. Other charts will get their own workflow when ready.
+
+name: ci
+
+on:
+  pull_request:
+    paths:
+      - "inspire/**"
+      - ".github/workflows/ci.yml"
+  push:
+    branches: [master]
+    paths:
+      - "inspire/**"
+      - ".github/workflows/ci.yml"
+  workflow_call:
+
+env:
+  HELM_VERSION: v3.16.3
+  KUBECONFORM_VERSION: v0.6.7
+  K8S_API_VERSION: "1.29.0"
+
+jobs:
+  lint-and-template:
+    name: Lint & template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      - name: helm lint (defaults)
+        run: helm lint inspire
+
+      - name: helm lint + template (every inspire/ci/*.yaml)
+        run: |
+          shopt -s nullglob
+          fixtures=(inspire/ci/*.yaml)
+          if [[ ${#fixtures[@]} -eq 0 ]]; then
+            echo "::error::no fixtures found under inspire/ci/"
+            exit 1
+          fi
+          mkdir -p /tmp/rendered
+          for f in "${fixtures[@]}"; do
+            name=$(basename "$f" .yaml)
+            echo "::group::lint $name"
+            helm lint inspire -f "$f"
+            echo "::endgroup::"
+            echo "::group::template $name"
+            helm template ci-test inspire -f "$f" > "/tmp/rendered/${name}.yaml"
+            echo "rendered $(grep -c '^kind:' /tmp/rendered/${name}.yaml) kinds → /tmp/rendered/${name}.yaml"
+            echo "::endgroup::"
+          done
+
+      - name: kubeconform (rendered manifests)
+        run: |
+          kubeconform \
+            -strict \
+            -summary \
+            -kubernetes-version "${K8S_API_VERSION}" \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            /tmp/rendered/*.yaml
+
+      - name: Upload rendered manifests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rendered-manifests
+          path: /tmp/rendered/
+          retention-days: 7
+
+  dry-run-on-kind:
+    name: helm install --dry-run on KinD
+    runs-on: ubuntu-latest
+    needs: lint-and-template
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Create KinD cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: spt-ci
+
+      - name: helm install --dry-run=server (every inspire/ci/*.yaml)
+        run: |
+          shopt -s nullglob
+          for f in inspire/ci/*.yaml; do
+            name=$(basename "$f" .yaml)
+            echo "::group::dry-run $name"
+            helm install ci-test inspire \
+              --dry-run=server \
+              --namespace ci-test \
+              --create-namespace \
+              -f "$f"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+# Release the inspire chart on tag push.
+#
+# Triggered by tags of the form `inspire-v*`. Re-runs Tier 1 gates from
+# ci.yml (via workflow_call), then packages the chart, pushes it as an
+# OCI artifact to GHCR, and signs the pushed artifact with cosign using
+# keyless OIDC (no long-lived signing keys).
+#
+# Chart bytes only — no Inspire image bytes are touched in this workflow.
+# Real-image smoke is a local pre-tag step (see RELEASING.md when added).
+#
+# The tag version (stripped of the `inspire-v` prefix) must match
+# inspire/Chart.yaml's `version:` field, or the workflow fails before push.
+
+name: release
+
+on:
+  push:
+    tags:
+      - "inspire-v*"
+
+concurrency:
+  group: release-inspire-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  HELM_VERSION: v3.16.3
+  COSIGN_VERSION: v2.4.1
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository_owner }}/charts
+
+jobs:
+  validate:
+    uses: ./.github/workflows/ci.yml
+
+  package-and-push:
+    name: Package, push, sign
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # required for cosign keyless OIDC
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Verify tag matches Chart.yaml version
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          tag_version="${TAG_REF#inspire-v}"
+          chart_version=$(awk '/^version:/ {print $2}' inspire/Chart.yaml | tr -d '"')
+          echo "tag version:   ${tag_version}"
+          echo "chart version: ${chart_version}"
+          if [[ "${tag_version}" != "${chart_version}" ]]; then
+            echo "::error::tag (${tag_version}) does not match inspire/Chart.yaml version (${chart_version})"
+            exit 1
+          fi
+          echo "CHART_VERSION=${chart_version}" >> "$GITHUB_ENV"
+
+      - name: Package chart
+        run: |
+          mkdir -p dist
+          helm package inspire --destination dist
+          ls -la dist/
+
+      - name: Log in to GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          echo "$GITHUB_TOKEN" \
+            | helm registry login "$REGISTRY" --username "$GHCR_USER" --password-stdin
+
+      - name: Push chart to GHCR (OCI)
+        id: push
+        run: |
+          chart_tgz="dist/inspire-${CHART_VERSION}.tgz"
+          oci_target="oci://${REGISTRY}/${REPOSITORY}"
+          # `helm push` writes Pushed/Digest lines to stderr; capture both streams.
+          push_out=$(helm push "$chart_tgz" "$oci_target" 2>&1 | tee /dev/stderr)
+          digest=$(echo "$push_out" | awk '/^Digest:/ {print $2}')
+          if [[ -z "$digest" ]]; then
+            echo "::error::could not parse digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REGISTRY}/${REPOSITORY}/inspire@${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart with cosign (keyless OIDC)
+        env:
+          ARTIFACT_REF: ${{ steps.push.outputs.ref }}
+        run: |
+          cosign sign --yes "$ARTIFACT_REF"
+
+      - name: Verify signature
+        env:
+          ARTIFACT_REF: ${{ steps.push.outputs.ref }}
+        run: |
+          cosign verify "$ARTIFACT_REF" \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,89 @@
+# Releasing
+
+How to cut a release of a chart in this repo.
+
+Currently in scope: **inspire**. Other charts will document their own release path here when their workflows come online.
+
+## inspire
+
+The CI workflow (`.github/workflows/ci.yml`) validates schema correctness on every PR. The release workflow (`.github/workflows/release.yml`) packages, pushes to GHCR, and signs with cosign on tag push. Both are necessary but not sufficient — they validate the chart artifact, not the deployed application. Tier 3 (real-image smoke against a real cluster) is a manual pre-tag step.
+
+### 1. Tier 3 local smoke install
+
+Before tagging, install the chart locally against a working K8s cluster with images from the official distribution repo pre-pulled (or credentials to a mirror) and confirm Inspire comes up healthy. This is the gate that catches anything Tier 1 (`ci.yml`) cannot — real image pulls, init-container ordering, JVM startup, probe behavior under real load.
+
+Reference cluster: colima with `vz + vz-rosetta`. Expected wall-clock: ~4.5 min.
+
+```bash
+# Prereqs: colima up, registry pull-secret applied, postgresql + elastic up,
+# license-server and admin-pass secrets present in target namespace.
+
+helm upgrade --install inspire ./inspire \
+  --namespace inspire \
+  --create-namespace \
+  --values <your-registry-pointing-values>.yaml \
+  --wait --timeout 10m
+```
+
+Verify:
+
+- All pods Ready (`kubectl -n inspire get pods`)
+- ICM, Interactive, and Scaler liveness probes passing
+- Interactive and Scaler UIs reachable
+- No `CrashLoopBackOff` or `ImagePullBackOff` events in the last 5 minutes
+
+If any of the above fails, **do not tag**. Open an issue / fix the chart / iterate values.
+
+### 2. Bump Chart.yaml version
+
+Reset the chart's `version:` field to the new refarch SemVer. The refarch tracks its own SemVer line — it is not tied to the upstream Quadient chart version. See the upstream attribution annotation (`com.quadient.spt.refarch.upstream-chart-version`) for the derivation pointer.
+
+```yaml
+# inspire/Chart.yaml
+version: 1.0.1 # or whatever the next refarch version is
+```
+
+Commit on a release branch or directly on master per workflow preference. The release workflow verifies the tag version equals this field; mismatch fails the workflow before any push.
+
+### 3. Tag and push
+
+```bash
+git tag inspire-v1.0.1
+git push origin inspire-v1.0.1
+```
+
+The push triggers `.github/workflows/release.yml`. Expected steps:
+
+1. `validate` job — re-runs `ci.yml` Tier 1 gates
+2. Tag-vs-Chart.yaml version equality check
+3. `helm package inspire`
+4. GHCR login (uses `GITHUB_TOKEN`)
+5. `helm push` to `oci://ghcr.io/<owner>/charts`
+6. `cosign sign` with keyless OIDC (no long-lived signing keys)
+7. `cosign verify` to confirm the signature is queryable
+
+If any step fails, the GHCR artifact may be partially published. Re-running requires deleting the tag, deleting the GHCR artifact version (if present), and re-pushing the tag. Prefer to dry-run via PR first.
+
+### 4. Post-release verification
+
+```bash
+# Confirm the artifact is pullable
+helm pull oci://ghcr.io/<owner>/charts/inspire --version 1.0.1
+
+# Confirm the signature
+cosign verify ghcr.io/<owner>/charts/inspire:1.0.1 \
+  --certificate-identity-regexp "^https://github.com/<owner>/spt-charts/" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+# Confirm annotations are present
+helm show chart oci://ghcr.io/<owner>/charts/inspire --version 1.0.1 \
+  | grep -A2 '^annotations:'
+```
+
+### 5. Rollback (if needed)
+
+OCI artifacts in GHCR cannot be overwritten by re-pushing the same version. To replace a bad release:
+
+1. Delete the tag locally and on origin: `git tag -d inspire-v1.0.1 && git push origin :inspire-v1.0.1`
+2. Delete the package version from GHCR (Settings → Packages → `inspire` → version → Delete)
+3. Fix the issue, bump the patch version (don't reuse the deleted version), re-tag

--- a/inspire/Chart.yaml
+++ b/inspire/Chart.yaml
@@ -3,4 +3,20 @@ appVersion: "17.4"
 description: Inspire
 name: inspire
 type: application
-version: 4.0.0
+version: 1.0.0
+annotations:
+  com.quadient.spt.refarch.upstream-chart-version: "4.0.0"
+  org.opencontainers.image.source: "https://github.com/robertwtucker/spt-charts"
+dependencies:
+  - name: automation
+    version: "4.0.0"
+    repository: "file:charts/automation"
+  - name: icm
+    version: "4.0.0"
+    repository: "file:charts/icm"
+  - name: interactive
+    version: "4.0.0"
+    repository: "file:charts/interactive"
+  - name: scaler
+    version: "4.0.0"
+    repository: "file:charts/scaler"

--- a/inspire/ci/values-vanilla.yaml
+++ b/inspire/ci/values-vanilla.yaml
@@ -1,0 +1,178 @@
+# CI fixture: representative production-shaped values for the inspire chart.
+# Used by ci.yml to verify the chart renders under realistic configuration.
+# NOT a deployable values file — image tags are placeholders.
+
+global:
+  imagePullSecrets:
+    - spt-registry
+  applicationName: "inspire"
+  icm:
+    adminPassOverrideSource:
+      useSecret: true
+      secretName: "spt-secrets"
+      secretKey: "admin-pass"
+  scaler:
+    enabled: true
+    # enabled: false
+    passOverrideSource:
+      useSecret: true
+      secretName: "spt-secrets"
+      secretKey: "admin-pass"
+  interactive:
+    enabled: true
+    # enabled: false
+    passOverrideSource:
+      useSecret: true
+      secretName: "spt-secrets"
+      secretKey: "admin-pass"
+  sen:
+    # enabled: true
+    enabled: false
+    passOverrideSource:
+      useSecret: true
+      secretName: "spt-secrets"
+      secretKey: "admin-pass"
+  license:
+    method: "CL"
+    serverSource:
+      useSecret: true
+      secretName: "spt-secrets"
+      secretKey: "license-server"
+  dataRecording:
+    prepareEnvironment: false
+
+icm:
+  image:
+    name: "quadientdistribution.azurecr.io/flex/icm"
+    tag: "17.0-latest"
+  db:
+    host: "inspire-db-postgresql-hl"
+    port: "5432"
+    userSource:
+      useSecret: true
+      secretName: "postgresql"
+      secretKey: "postgres-user"
+    passSource:
+      useSecret: true
+      secretName: "postgresql"
+      secretKey: "postgres-password"
+    name: "icm"
+    type: "PostgreSql"
+  useInitialServerSettings: true
+  initialServerSettings:
+    packageImportExport:
+      overwriteExistingUsersOnImport: false
+      overwriteExistingGroupsAndSyncPointsOnImport: false
+      overwriteExistingApprovalStatesOnImport: false
+      overwriteServerPropertiesOnImport: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits: {}
+
+scaler:
+  installationType: Cluster
+  addJvmArguments: "-XX:MaxRAMPercentage=75.0"
+  livenessProbe:
+    initialDelaySeconds: 240
+  image:
+    name: "quadientdistribution.azurecr.io/flex/scaler"
+    tag: "17.0-latest"
+    ips:
+      name: "quadientdistribution.azurecr.io/flex/ips"
+      tag: "17.0-latest"
+    sen:
+      name: "quadientdistribution.azurecr.io/flex/scenario-engine"
+      tag: "17.0-latest"
+  db:
+    host: "inspire-db-postgresql-hl"
+    port: "5432"
+    userSource:
+      useSecret: true
+      secretName: "postgresql"
+      secretKey: "postgres-user"
+    passSource:
+      useSecret: true
+      secretName: "postgresql"
+      secretKey: "postgres-password"
+    name: "scaler"
+    type: "PostgreSql"
+  sharedStorage:
+    size: 2Gi
+    existingClaim: "example-shared-storage"
+  additionalStorage:
+    enabled: false
+    existingClaim: ""
+  customLoggerConfigCM: example-logger-config
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: "1500m"
+      memory: 3Gi
+  ips:
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        cpu: "500m"
+  sen:
+    resources:
+      requests:
+        cpu: 150m
+        memory: 1Gi
+      limits: {}
+    db:
+      connectionString: "jdbc:postgresql://inspire-db-postgresql-hl:5432/scenario"
+      userSource:
+        useSecret: true
+        secretName: "postgresql"
+        secretKey: "postgres-user"
+      passSource:
+        useSecret: true
+        secretName: "postgresql"
+        secretKey: "postgres-password"
+interactive:
+  addJvmArguments: "-XX:MaxRAMPercentage=75.0"
+  livenessProbe:
+    initialDelaySeconds: 120
+  image:
+    name: "quadientdistribution.azurecr.io/flex/interactive"
+    tag: "17.0-latest"
+    ips:
+      name: "quadientdistribution.azurecr.io/flex/ips"
+      tag: "17.0-latest"
+  db:
+    host: "inspire-db-postgresql-hl"
+    port: "5432"
+    userSource:
+      useSecret: true
+      secretName: "postgresql"
+      secretKey: "postgres-user"
+    passSource:
+      useSecret: true
+      secretName: "postgresql"
+      secretKey: "postgres-password"
+    name: "interactive"
+    type: "PostgreSql"
+  resources:
+    requests:
+      cpu: 250m
+      memory: 2Gi
+    limits:
+      cpu: "1500m"
+      memory: 3Gi
+  productionEnvironment: false
+  ips:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "500m"
+  fulltext:
+    enabled: false
+    host: "http://inspire-es-elasticsearch:9200"


### PR DESCRIPTION
## Summary

Brings up GitHub Actions for the inspire chart as the first leg of W25 (target tag `inspire-v1.0.0`).

- `inspire/Chart.yaml`: reset version to `1.0.0` (refarch's own SemVer line), add `dependencies:` block for vendored subcharts (fixes pre-existing `helm lint` failure), add OCI annotations for upstream attribution and source pointer
- `.github/workflows/ci.yml`: Tier 1 gates (lint → template → kubeconform → KinD dry-run), scoped to `inspire/**`, exposes `workflow_call` for reuse
- `.github/workflows/release.yml`: tag-triggered (`inspire-v*`), re-runs ci.yml via `workflow_call`, packages, pushes to GHCR as OCI, signs with cosign keyless OIDC
- `inspire/ci/values-vanilla.yaml`: first CI fixture — representative production-shaped values with placeholder image tags (non-deployable by design; only needs to render and admit)

Tier 2 (image-stub installs) and Tier 3 (real-image smoke) are out of scope here. Tier 3 stays as a local pre-tag step — real Inspire images live behind credentialled Harbor that GitHub-hosted runners cannot reach, and putting prod-equivalent registry creds in repo secrets is the wrong trust boundary.

## Test plan

This PR's primary purpose is to dry-run `ci.yml` against real GHA runners before tagging. The `release.yml` workflow cannot be exercised from a PR (it's tag-triggered) but its `validate` job — which calls `ci.yml` via `workflow_call` — is exercised by the same checks that run on this PR.

- [ ] `lint-and-template` job passes
  - [ ] `helm lint inspire` clean
  - [ ] `helm lint + template` for each `inspire/ci/*.yaml` clean
  - [ ] `kubeconform` clean against K8s 1.29 OpenAPI
  - [ ] Rendered manifests uploaded as artifact
- [ ] `dry-run-on-kind` job passes
  - [ ] KinD cluster spins up
  - [ ] `helm install --dry-run=server` succeeds for each fixture

After merge:
- [ ] Write `RELEASING.md` documenting Tier 3 local-smoke checklist
- [ ] Local Tier 3 smoke install against colima with real Harbor creds
- [ ] Tag `inspire-v1.0.0` to exercise `release.yml` end-to-end (GHCR push + cosign sign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)