### PR TITLE
fix(docuhost): rollout-on-change annotations + mongo app-user provisioning

### DIFF
--- a/docuhost/Chart.yaml
+++ b/docuhost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.5.10
+appVersion: 0.6.1
 description: A Helm chart to deploy the Document Host (Docuhost) demo service
 name: docuhost
 type: application
-version: 0.3.1
+version: 0.4.0

--- a/docuhost/Chart.yaml
+++ b/docuhost/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.5.10
 description: A Helm chart to deploy the Document Host (Docuhost) demo service
 name: docuhost
 type: application
-version: 0.3.0
+version: 0.3.1

--- a/docuhost/templates/NOTES.txt
+++ b/docuhost/templates/NOTES.txt
@@ -19,3 +19,25 @@ Access the Application:
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+{{- if .Values.mongodb.enabled }}
+
+MongoDB application user:
+  The "{{ .Values.db.username | default "docuhost" }}" user is auto-created on the FIRST mongo start
+  (the init script under /docker-entrypoint-initdb.d only runs against an empty
+  data volume). If you are upgrading an existing install where the volume
+  already has data, create the user once manually:
+
+    ROOT_PW=$(kubectl --namespace {{ .Release.Namespace }} get secret {{ include "docuhost.mongodb.fullname" . }} \
+      -o jsonpath='{.data.mongodb-root-password}' | base64 -d)
+    APP_PW=$(kubectl --namespace {{ .Release.Namespace }} get secret {{ include "docuhost.mongodb.fullname" . }} \
+      -o jsonpath='{.data.mongodb-password}' | base64 -d)
+    kubectl --namespace {{ .Release.Namespace }} exec -i {{ include "docuhost.mongodb.fullname" . }}-0 -- \
+      mongosh --quiet -u root -p "$ROOT_PW" --authenticationDatabase admin --eval "
+        db = db.getSiblingDB('{{ .Values.db.name | default "documents" }}');
+        db.createUser({
+          user:  '{{ .Values.db.username | default "docuhost" }}',
+          pwd:   '$APP_PW',
+          roles: [{ role: 'readWrite', db: '{{ .Values.db.name | default "documents" }}' }]
+        });"
+{{- end }}

--- a/docuhost/templates/_helpers.tpl
+++ b/docuhost/templates/_helpers.tpl
@@ -105,7 +105,7 @@ Return the configuration configmap name
 Return true if a configmap object should be created
 */}}
 {{- define "docuhost.createConfigMap" }}
-{{- if empty .Values.existingConfigmap }}
+{{- if empty .Values.existingConfigMap }}
     {{- true }}
 {{- end }}
 {{- end }}

--- a/docuhost/templates/deployment.yaml
+++ b/docuhost/templates/deployment.yaml
@@ -15,8 +15,17 @@ spec:
     type: Recreate
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
-      annotations: {{ .Values.podAnnotations | toYaml | nindent 8 }}
+      {{- if or (include "docuhost.createConfigMap" .) (include "docuhost.createSecret" .) .Values.podAnnotations }}
+      annotations:
+        {{- if include "docuhost.createConfigMap" . }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if include "docuhost.createSecret" . }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels: {{- include "docuhost.labels" . | nindent 8 }}
         app.kubernetes.io/component: docuhost

--- a/docuhost/templates/mongodb-init-configmap.yaml
+++ b/docuhost/templates/mongodb-init-configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.mongodb.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "docuhost.mongodb.fullname" . }}-init
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "docuhost.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+data:
+  init-user.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mongosh --quiet \
+      --username "$MONGO_INITDB_ROOT_USERNAME" \
+      --password "$MONGO_INITDB_ROOT_PASSWORD" \
+      --authenticationDatabase admin <<EOF
+    db = db.getSiblingDB("$MONGO_APP_DB");
+    db.createUser({
+      user:  "$MONGO_APP_USERNAME",
+      pwd:   "$MONGO_APP_PASSWORD",
+      roles: [{ role: "readWrite", db: "$MONGO_APP_DB" }]
+    });
+    EOF
+{{- end }}

--- a/docuhost/templates/mongodb-statefulset.yaml
+++ b/docuhost/templates/mongodb-statefulset.yaml
@@ -38,6 +38,15 @@ spec:
                   key: mongodb-root-password
             - name: MONGO_INITDB_DATABASE
               value: {{ .Values.db.name | default "documents" | quote }}
+            - name: MONGO_APP_DB
+              value: {{ .Values.db.name | default "documents" | quote }}
+            - name: MONGO_APP_USERNAME
+              value: {{ .Values.db.username | default "docuhost" | quote }}
+            - name: MONGO_APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "docuhost.mongodb.fullname" . }}
+                  key: mongodb-password
           {{- if .Values.mongodb.resources }}
           resources: {{- .Values.mongodb.resources | toYaml | nindent 12 }}
           {{- end }}
@@ -59,11 +68,19 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5
-          {{- if .Values.mongodb.persistence.enabled }}
           volumeMounts:
+            {{- if .Values.mongodb.persistence.enabled }}
             - name: data
               mountPath: /data/db
-          {{- end }}
+            {{- end }}
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ include "docuhost.mongodb.fullname" . }}-init
+            defaultMode: 0755
       {{- if .Values.mongodb.nodeSelector }}
       nodeSelector: {{- .Values.mongodb.nodeSelector | toYaml | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
- Closes #102
- Closes #103

## Summary

- **#102** — Adds `checksum/config` + `checksum/secret` pod-template annotations to the `docuhost` Deployment so `helm upgrade` rolls the pod automatically when ConfigMap/Secret content changes. Gated on chart-managed render (no false rollouts when `existingConfigMap` / `existingSecret` are in use).
- **#102 drive-by** — Fixes a latent typo in `docuhost.createConfigMap` (`existingConfigmap` → `existingConfigMap`) that was activated as a render gate by the checksum change. Side benefit: chart no longer renders a redundant chart-managed ConfigMap when `existingConfigMap` is supplied.
- **#103** — Provisions the application `docuhost` user (matching `db.username` / `db.name`) on first mongo start via a shell init script under `/docker-entrypoint-initdb.d/`. Password is sourced from the existing `mongodb-password` secret key — no secrets rendered into ConfigMaps. NOTES.txt includes a manual `kubectl exec` snippet for upgrading existing installs whose PVC already has data (init scripts won't re-run).

Chart bump: `0.3.0 → 0.4.0`. appVersion bump: `0.5.10 → 0.6.1`.

Two commits, one per issue.

## Test plan

Verified end-to-end against local colima k3s (v1.35.0+k3s1):

- [x] Fresh `helm install` — mongo `dh-docuhost-mongodb-0` Ready; init script logged `running /docker-entrypoint-initdb.d/init-user.sh`; `db.getSiblingDB("documents").getUsers()` returns `docuhost` with `readWrite` on `documents`.
- [x] App pod reaches `Ready 1/1` (passes `/api/v2/healthcheck`, which authenticates against mongo). No `MongoServerError: Authentication failed` lines.
- [x] `kubectl get deploy/dh-docuhost -o jsonpath=...annotations` shows both `checksum/config` and `checksum/secret`.
- [x] `helm upgrade --set shortlink.domain=…` (a ConfigMap-managed value) → `checksum/config` changes; new ReplicaSet hash; new pod comes up automatically with no `kubectl rollout restart`.
- [x] No-op `helm upgrade --reuse-values` → pod name unchanged; checksums stable; no false-positive rollouts.
- [x] `helm template … --set existingConfigMap=my-cm` → chart-managed `configmap.yaml` not rendered (helper-typo fix).
- [x] **Not exercised in this PR:** upgrade-from-existing-install path (0.3.0 with mongo data already on PVC, then upgrade to this PR). NOTES.txt is written for that case; reviewer may want to verify the manual snippet there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)