### PR TITLE
ci: bump actions off Node.js 20 + enable Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot configuration.
+#
+# Currently scoped to GitHub Actions only — Helm chart dependencies
+# (the `dependencies:` block in each Chart.yaml) are not on this
+# update cadence and continue to be bumped manually.
+#
+# Schedule: monthly. Updates are grouped so the maintainer reviews
+# one PR per month rather than one PR per action.
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci-docuhost.yml
+++ b/.github/workflows/ci-docuhost.yml
@@ -39,10 +39,10 @@ jobs:
     name: Lint & template
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload rendered manifests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rendered-manifests-docuhost
           path: /tmp/rendered/
@@ -98,10 +98,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-template
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 

--- a/.github/workflows/ci-inspire.yml
+++ b/.github/workflows/ci-inspire.yml
@@ -38,10 +38,10 @@ jobs:
     name: Lint & template
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload rendered manifests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rendered-manifests
           path: /tmp/rendered/
@@ -97,10 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-template
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 

--- a/.github/workflows/release-docuhost.yml
+++ b/.github/workflows/release-docuhost.yml
@@ -42,10 +42,10 @@ jobs:
       packages: write
       id-token: write   # required for cosign keyless OIDC
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 

--- a/.github/workflows/release-inspire.yml
+++ b/.github/workflows/release-inspire.yml
@@ -41,10 +41,10 @@ jobs:
       packages: write
       id-token: write   # required for cosign keyless OIDC
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 


### PR DESCRIPTION
## Summary

Resolves the Node.js 20 deprecation warning that fired during the `docuhost-v0.4.0` release run, and sets up Dependabot so we don't drift back into the same situation.

**Two commits:**

1. **`ci: bump actions off Node.js 20 to clear deprecation warning`** — bumps the three action majors flagged by GitHub:

   | Action | Was | Now | Latest tag | Runtime |
   |---|---|---|---|---|
   | `actions/checkout` | v4 | **v6** | v6.0.3 | node24 |
   | `actions/upload-artifact` | v4 | **v7** | v7.0.1 | node24 |
   | `azure/setup-helm` | v4 | **v5** | v5.0.0 | node24 |

   Unchanged:
   - `helm/kind-action@v1` — already on latest major (v1.14.0, node24)
   - `sigstore/cosign-installer@v3` — composite action, not affected by Node deprecation. Bumping to v4 would also change the default installed cosign version (v2.x → v3.x), which is a separate concern.

2. **`chore(ci): enable Dependabot for monthly grouped action updates`** — adds `.github/dependabot.yml` scoped to `github-actions` with monthly cadence and a single group covering all actions, so future bumps arrive as one PR per month rather than one PR per action.

## What's NOT in this PR

- Cosign-installer v3 → v4 + cosign v2.x → v3.x bump. Filing as a separate follow-up — needs a `cosign verify` against an existing v2-signed artifact (e.g. `inspire-v1.0.0` or the just-published `docuhost-v0.4.0`) to confirm cross-version verification.
- Helm chart dependency scanning. Dependabot's github-actions ecosystem covers `uses:` only; the `dependencies:` blocks in each `Chart.yaml` continue to be bumped manually as part of chart releases.

## Test plan

- [x] `grep` confirms no `(checkout|upload-artifact|setup-helm)@v4` lingers in `.github/workflows/`
- [x] `helm/kind-action@v1` and `sigstore/cosign-installer@v3` retained intentionally
- [ ] **Verified by this PR's own CI run** — both `ci (inspire)` and `ci (docuhost)` paths cover `.github/workflows/**`, so both should fire here on the bumped versions. The upload-artifact v4→v7 change is the highest-risk piece; success on the artifact-upload step is the signal.
- [ ] **Verified post-merge** — Dependabot's first scan will be a no-op (we've already done the work it would propose); the second scan a month from now will exercise the grouped-PR path for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)