### PR TITLE
ci(adapt): bring up Tier 1 validation and tag-triggered OCI release

### DIFF
--- a/.github/workflows/ci-adapt.yml
+++ b/.github/workflows/ci-adapt.yml
@@ -62,12 +62,14 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
-      # The post-renderer shells out to `kubectl kustomize`; pin it rather
-      # than rely on the runner image's bundled kubectl.
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: ${{ env.KUBECTL_VERSION }}
+      # The post-renderer shells out to `kubectl kustomize`. Install via
+      # curl (not azure/setup-kubectl, which still targets Node.js 20);
+      # matches the kubeconform install below.
+      - name: Install kubectl
+        run: |
+          curl -sSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          sudo install -m 0755 kubectl /usr/local/bin/kubectl
+          kubectl version --client
 
       - name: Install kubeconform
         run: |
@@ -139,10 +141,12 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: ${{ env.KUBECTL_VERSION }}
+      # kubectl for the post-renderer's `kubectl kustomize` (see lint job).
+      - name: Install kubectl
+        run: |
+          curl -sSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          sudo install -m 0755 kubectl /usr/local/bin/kubectl
+          kubectl version --client
 
       - name: helm dependency build
         run: helm dependency build adapt

--- a/.github/workflows/ci-adapt.yml
+++ b/.github/workflows/ci-adapt.yml
@@ -1,0 +1,171 @@
+# CI for the adapt chart (Tier 1: schema-only).
+#
+# This workflow validates that the chart and its CI fixtures render and
+# admit cleanly. It does NOT install or pull real Adapt/Inspire images —
+# those live behind credentialled registries that GitHub-hosted runners
+# cannot reach, and putting those creds in repo secrets is the wrong trust
+# boundary. Real-image smoke (Tier 3) is a local pre-tag step (RELEASING.md).
+#
+# Two things make adapt's pipeline differ from inspire/docuhost:
+#
+#   * Helm 4 is REQUIRED, not optional. The post-renderer ships as a Helm 4
+#     plugin (`type: postrenderer/v1`, subprocess runtime) and CI invokes it
+#     by name (`--post-renderer adapt-scaler-inject`) — both are Helm 4-only.
+#     The v3.16.3 pin used by the other charts would fail on plugin install.
+#
+#   * The chart has an OCI subchart dependency (inspire). `*.tgz` is
+#     gitignored, so a fresh checkout has only Chart.lock — `helm dependency
+#     build` reconstructs adapt/charts/ from the locked digest (public GHCR,
+#     anonymous pull) before anything else can lint/template/render.
+#
+# The post-renderer is applied to EVERY fixture. kustomize-post.sh passes
+# input through unchanged when no `inspire-scaler` Deployment is present, so
+# it is safe to run unconditionally — no per-fixture branching needed.
+#
+# Gates (fast → slow):
+#   1. helm lint       — deprecated APIs, missing Chart.yaml fields
+#   2. helm template   — every fixture under adapt/ci/ must render (+inject)
+#   3. kubeconform     — rendered manifests validate against K8s OpenAPI
+#   4. helm install --dry-run=server on KinD — admission/webhook checks
+#
+# Scope: adapt only. Inspire and docuhost have their own pipelines.
+
+name: ci (adapt)
+
+on:
+  pull_request:
+    paths:
+      - "adapt/**"
+      - ".github/workflows/ci-adapt.yml"
+  push:
+    branches: [master]
+    paths:
+      - "adapt/**"
+      - ".github/workflows/ci-adapt.yml"
+  workflow_call:
+
+env:
+  HELM_VERSION: v4.2.1
+  KUBECTL_VERSION: v1.36.2
+  KUBECONFORM_VERSION: v0.6.7
+  K8S_API_VERSION: "1.29.0"
+
+jobs:
+  lint-and-template:
+    name: Lint & template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # The post-renderer shells out to `kubectl kustomize`; pin it rather
+      # than rely on the runner image's bundled kubectl.
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: ${{ env.KUBECTL_VERSION }}
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      # Reconstruct adapt/charts/ from Chart.lock (inspire subchart is an
+      # OCI dep; the .tgz is gitignored). Anonymous pull from public GHCR.
+      - name: helm dependency build
+        run: helm dependency build adapt
+
+      # Install the Helm 4 post-renderer plugin so `--post-renderer
+      # adapt-scaler-inject` resolves by name below.
+      - name: Install post-renderer plugin
+        run: helm plugin install ./adapt/post-renderer
+
+      - name: helm lint (defaults)
+        run: helm lint adapt
+
+      - name: helm lint + template (every adapt/ci/*.yaml)
+        run: |
+          shopt -s nullglob
+          fixtures=(adapt/ci/*.yaml)
+          if [[ ${#fixtures[@]} -eq 0 ]]; then
+            echo "::error::no fixtures found under adapt/ci/"
+            exit 1
+          fi
+          mkdir -p /tmp/rendered
+          for f in "${fixtures[@]}"; do
+            name=$(basename "$f" .yaml)
+            echo "::group::lint $name"
+            helm lint adapt -f "$f"
+            echo "::endgroup::"
+            echo "::group::template $name"
+            helm template ci-test adapt -f "$f" \
+              --post-renderer adapt-scaler-inject > "/tmp/rendered/${name}.yaml"
+            echo "rendered $(grep -c '^kind:' /tmp/rendered/${name}.yaml) kinds → /tmp/rendered/${name}.yaml"
+            echo "::endgroup::"
+          done
+
+      - name: kubeconform (rendered manifests)
+        run: |
+          kubeconform \
+            -strict \
+            -summary \
+            -kubernetes-version "${K8S_API_VERSION}" \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            /tmp/rendered/*.yaml
+
+      - name: Upload rendered manifests
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rendered-manifests-adapt
+          path: /tmp/rendered/
+          retention-days: 7
+
+  dry-run-on-kind:
+    name: helm install --dry-run on KinD
+    runs-on: ubuntu-latest
+    needs: lint-and-template
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: ${{ env.KUBECTL_VERSION }}
+
+      - name: helm dependency build
+        run: helm dependency build adapt
+
+      - name: Install post-renderer plugin
+        run: helm plugin install ./adapt/post-renderer
+
+      - name: Create KinD cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: spt-ci-adapt
+
+      - name: helm install --dry-run=server (every adapt/ci/*.yaml)
+        run: |
+          shopt -s nullglob
+          for f in adapt/ci/*.yaml; do
+            name=$(basename "$f" .yaml)
+            echo "::group::dry-run $name"
+            helm install ci-test adapt \
+              --dry-run=server \
+              --namespace ci-test \
+              --create-namespace \
+              --post-renderer adapt-scaler-inject \
+              -f "$f"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/release-adapt.yml
+++ b/.github/workflows/release-adapt.yml
@@ -1,0 +1,134 @@
+# Release the adapt chart on tag push.
+#
+# Triggered by tags of the form `adapt-v*`. Re-runs Tier 1 gates from
+# ci-adapt.yml (via workflow_call), then packages the chart, pushes it as
+# an OCI artifact to GHCR, and signs the pushed artifact with cosign using
+# keyless OIDC (no long-lived signing keys).
+#
+# Chart bytes only — no Adapt/Inspire image bytes are touched here.
+# Real-image smoke is a local pre-tag step (see RELEASING.md).
+#
+# Adapt-specific notes:
+#   * `helm dependency build` runs before `helm package` so the published
+#     adapt chart bundles its locked inspire-1.0.0 subchart (adapt/charts/
+#     is gitignored; only Chart.lock is committed).
+#   * The post-renderer plugin is NOT packaged — adapt/.helmignore excludes
+#     post-renderer/, so it never lands in the OCI artifact. It ships
+#     separately via `helm plugin install`. Nothing to do here for it.
+#
+# The tag version (stripped of the `adapt-v` prefix) must match
+# adapt/Chart.yaml's `version:` field, or the workflow fails before push.
+
+name: release (adapt)
+
+on:
+  push:
+    tags:
+      - "adapt-v*"
+
+concurrency:
+  group: release-adapt-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  HELM_VERSION: v4.2.1
+  COSIGN_VERSION: v2.4.1
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository_owner }}/charts
+
+jobs:
+  validate:
+    uses: ./.github/workflows/ci-adapt.yml
+
+  package-and-push:
+    name: Package, push, sign
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # required for cosign keyless OIDC
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Verify tag matches Chart.yaml version
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          tag_version="${TAG_REF#adapt-v}"
+          chart_version=$(awk '/^version:/ {print $2}' adapt/Chart.yaml | tr -d '"')
+          echo "tag version:   ${tag_version}"
+          echo "chart version: ${chart_version}"
+          if [[ "${tag_version}" != "${chart_version}" ]]; then
+            echo "::error::tag (${tag_version}) does not match adapt/Chart.yaml version (${chart_version})"
+            exit 1
+          fi
+          echo "CHART_VERSION=${chart_version}" >> "$GITHUB_ENV"
+
+      # Reconstruct adapt/charts/ from Chart.lock so `helm package` bundles
+      # the inspire subchart. Anonymous pull from public GHCR.
+      - name: helm dependency build
+        run: helm dependency build adapt
+
+      - name: Package chart
+        run: |
+          mkdir -p dist
+          helm package adapt --destination dist
+          ls -la dist/
+
+      - name: Log in to GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          echo "$GITHUB_TOKEN" \
+            | helm registry login "$REGISTRY" --username "$GHCR_USER" --password-stdin
+
+      - name: Push chart to GHCR (OCI)
+        id: push
+        run: |
+          chart_tgz="dist/adapt-${CHART_VERSION}.tgz"
+          oci_target="oci://${REGISTRY}/${REPOSITORY}"
+          # `helm push` writes Pushed/Digest lines to stderr; capture both streams.
+          push_out=$(helm push "$chart_tgz" "$oci_target" 2>&1 | tee /dev/stderr)
+          digest=$(echo "$push_out" | awk '/^Digest:/ {print $2}')
+          if [[ -z "$digest" ]]; then
+            echo "::error::could not parse digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REGISTRY}/${REPOSITORY}/adapt@${digest}" >> "$GITHUB_OUTPUT"
+
+      # cosign needs its own registry login — `helm registry login` writes a
+      # credential store cosign doesn't read. Skipping this bit Robert once
+      # (6282e4b): sign fails with a 401 after a clean push.
+      - name: Log in to GHCR for cosign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          cosign login "$REGISTRY" --username "$GHCR_USER" --password "$GITHUB_TOKEN"
+
+      - name: Sign chart with cosign (keyless OIDC)
+        env:
+          ARTIFACT_REF: ${{ steps.push.outputs.ref }}
+        run: |
+          cosign sign --yes "$ARTIFACT_REF"
+
+      - name: Verify signature
+        env:
+          ARTIFACT_REF: ${{ steps.push.outputs.ref }}
+        run: |
+          cosign verify "$ARTIFACT_REF" \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 How to cut a release of a chart in this repo.
 
-Currently in scope: **inspire**. Other charts will document their own release path here when their workflows come online.
+Currently in scope: **inspire** and **adapt**. Other charts will document their own release path here when their workflows come online.
 
 ## inspire
 
@@ -86,4 +86,101 @@ OCI artifacts in GHCR cannot be overwritten by re-pushing the same version. To r
 
 1. Delete the tag locally and on origin: `git tag -d inspire-v1.0.1 && git push origin :inspire-v1.0.1`
 2. Delete the package version from GHCR (Settings → Packages → `inspire` → version → Delete)
+3. Fix the issue, bump the patch version (don't reuse the deleted version), re-tag
+
+## adapt
+
+The CI workflow (`.github/workflows/ci-adapt.yml`) validates schema correctness on every PR. The release workflow (`.github/workflows/release-adapt.yml`) packages, pushes to GHCR, and signs with cosign on tag push. As with inspire, these validate the chart artifact, not the deployed application — Tier 3 (real-image smoke against a real cluster) is a manual pre-tag step.
+
+Two things make adapt's release differ from inspire's:
+
+- **OCI subchart dependency.** adapt depends on `inspire` pulled from `oci://ghcr.io/robertwtucker/charts`. `*.tgz` is gitignored, so only `adapt/Chart.lock` is committed — both CI and release run `helm dependency build adapt` to reconstruct `adapt/charts/` from the locked digest. The published adapt chart bundles its locked inspire subchart.
+- **Post-renderer ships separately.** The Helm 4 post-renderer plugin (`adapt-scaler-inject`) lives at `adapt/post-renderer/` but is excluded from the package by `adapt/.helmignore`. It is NOT in the published OCI artifact; consumers install it once per machine via `helm plugin install`. Because it requires `--post-renderer` resolution by plugin name, **adapt requires Helm 4** (the workflows pin `v4.2.1`).
+
+### 1. Tier 3 local smoke install
+
+Before tagging, install the chart locally against a working K8s cluster and confirm the License Server serves licenses and (on the integrated path) the Scaler can exec UA end-to-end. This is the gate that catches what Tier 1 (`ci-adapt.yml`) cannot — real binary-license validation, init-container ordering, and the post-renderer's Scaler injection running against live images.
+
+```bash
+# Prereqs: cluster up, registry pull-secret + spt-secrets/postgresql secrets
+# present in the target namespace, inspire dependencies (db, etc.) available.
+
+# Reconstruct the inspire subchart (matches what CI/release do).
+helm dependency build ./adapt
+
+# Install the post-renderer plugin once per machine.
+helm plugin install ./adapt/post-renderer
+
+# Real Adapt licenses are binary — pass them with --set-file, not --set.
+helm upgrade --install adapt ./adapt \
+  --namespace adapt \
+  --create-namespace \
+  --set-file licenseServer.license=./LicSer.lic \
+  --set-file ua.license=./adeptua.lic \
+  --values <your-registry-pointing-values>.yaml \
+  --post-renderer adapt-scaler-inject \
+  --wait --timeout 10m
+```
+
+Verify:
+
+- License Server pod Ready; `cdplicser` serving on its Service (LS clients can check out a license)
+- On the integrated path: Inspire Scaler pod Ready, `deploy-ua` initContainer completed, and Scaler can exec UA binaries from `/opt/adapt/ua`
+- No `CrashLoopBackOff` or `ImagePullBackOff` events in the last 5 minutes
+
+If any of the above fails, **do not tag**. Open an issue / fix the chart / iterate values.
+
+### 2. Bump Chart.yaml version
+
+Reset the chart's `version:` field to the new refarch SemVer. The refarch tracks its own SemVer line, decoupled from the upstream Adapt component versions (see the `com.quadient.spt.refarch.adapt-*-version` annotations for the derivation pointers).
+
+```yaml
+# adapt/Chart.yaml
+version: 1.0.1 # or whatever the next refarch version is
+```
+
+The release workflow verifies the tag version equals this field; mismatch fails the workflow before any push.
+
+### 3. Tag and push
+
+```bash
+git tag adapt-v1.0.1
+git push origin adapt-v1.0.1
+```
+
+The push triggers `.github/workflows/release-adapt.yml`. Expected steps:
+
+1. `validate` job — re-runs `ci-adapt.yml` Tier 1 gates
+2. Tag-vs-Chart.yaml version equality check
+3. `helm dependency build adapt` (so the package bundles inspire)
+4. `helm package adapt`
+5. GHCR login (uses `GITHUB_TOKEN`)
+6. `helm push` to `oci://ghcr.io/<owner>/charts`
+7. `cosign sign` with keyless OIDC (no long-lived signing keys)
+8. `cosign verify` to confirm the signature is queryable
+
+If any step fails, the GHCR artifact may be partially published. Re-running requires deleting the tag, deleting the GHCR artifact version (if present), and re-pushing the tag. Prefer to dry-run via PR first.
+
+### 4. Post-release verification
+
+```bash
+# Confirm the artifact is pullable
+helm pull oci://ghcr.io/<owner>/charts/adapt --version 1.0.1
+
+# Confirm the signature
+cosign verify ghcr.io/<owner>/charts/adapt:1.0.1 \
+  --certificate-identity-regexp "^https://github.com/<owner>/spt-charts/" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+# Confirm annotations are present
+helm show chart oci://ghcr.io/<owner>/charts/adapt --version 1.0.1 \
+  | grep -A2 '^annotations:'
+```
+
+### 5. Rollback (if needed)
+
+OCI artifacts in GHCR cannot be overwritten by re-pushing the same version. To replace a bad release:
+
+1. Delete the tag locally and on origin: `git tag -d adapt-v1.0.1 && git push origin :adapt-v1.0.1`
+2. Delete the package version from GHCR (Settings → Packages → `adapt` → version → Delete)
 3. Fix the issue, bump the patch version (don't reuse the deleted version), re-tag


### PR DESCRIPTION
Adds the adapt chart's CI/release pipeline pair (modeled on the inspire/docuhost workflows) plus its `RELEASING.md` section. Follow-up to the chart seed in `168ffe0`.

## What's here
- `.github/workflows/ci-adapt.yml` — Tier 1: `helm lint` → `helm template` (+inject) → `kubeconform` → `helm install --dry-run=server` on KinD. PR/push paths-filtered to `adapt/**`, plus `workflow_call`.
- `.github/workflows/release-adapt.yml` — `adapt-v*` tag trigger → reuse CI via `workflow_call` → version check → `helm dependency build` → package → GHCR OCI push → `cosign sign` + `verify`.
- `RELEASING.md` — new **adapt** section (Tier 3 smoke → bump → tag → verify → rollback).

## Two deliberate deviations from the inspire/docuhost skeleton
Both forced by the chart's shape:

1. **Helm 4 (pinned `v4.2.1`), not `v3.16.3`.** The post-renderer ships as a Helm 4 plugin (`type: postrenderer/v1`) and CI invokes it by name (`--post-renderer adapt-scaler-inject`) — both Helm 4-only. v3 fails at `helm plugin install`. `v4.2.1` is the version the chart was cluster-verified against.
2. **`helm dependency build` before lint/package.** adapt depends on the inspire OCI subchart; `*.tgz` is gitignored so a fresh checkout has only `Chart.lock`. The released chart bundles its locked inspire subchart.

The post-renderer is applied to **every** fixture — `kustomize-post.sh` passes input through unchanged when no `inspire-scaler` Deployment is present, so no per-fixture branching. `kubectl` is pinned (`v1.36.2`) for the post-renderer's `kubectl kustomize` call. At release time the post-renderer is excluded from the package by `.helmignore` and ships separately via `helm plugin install`.

## Verification (local, Helm v4.2.1)
- `helm dependency build adapt` — anonymous GHCR pull ✅
- clean `helm plugin install ./adapt/post-renderer` ✅
- `helm lint adapt -f ci/values-vanilla.yaml` — 0 failed ✅
- `helm template … --post-renderer adapt-scaler-inject` — `deploy-ua` initContainer injected into `inspire-scaler`; **0** without the flag ✅
- `kubeconform -strict` on post-rendered output — **20/20 valid** ✅

## Out of scope (known gaps, not addressed here)
- docuhost still has no `RELEASING.md` section (pre-existing; deferred by request).
- The inspire section still references the old `ci.yml` / `release.yml` names (renamed when pipelines were split per-chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)